### PR TITLE
One environment variable instead of three

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,9 +62,7 @@ Usage
 
     ::
 
-        ETHEREUM_NODE_HOST = 'localhost'
-        ETHEREUM_NODE_PORT = 8545
-        ETHEREUM_NODE_SSL = False
+        ETHEREUM_NODE_URI = 'http://localhost:8545'
          
          
 2.  Create a new MonitoredEvent

--- a/django_ethereum_events/web3_service.py
+++ b/django_ethereum_events/web3_service.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
@@ -19,11 +18,7 @@ class Web3Service(metaclass=Singleton):
         if not rpc_provider:
             timeout = getattr(settings, "ETHEREUM_NODE_TIMEOUT", 10)
 
-            uri = "{scheme}://{host}:{port}".format(
-                host=settings.ETHEREUM_NODE_HOST,
-                port=settings.ETHEREUM_NODE_PORT,
-                scheme="https" if settings.ETHEREUM_NODE_SSL else "http",
-            )
+            uri = settings.ETHEREUM_NODE_PORT
             rpc_provider = HTTPProvider(
                 endpoint_uri=uri,
                 request_kwargs={


### PR DESCRIPTION
Hi @artemistomaras @drdaeman 

I use this module in my project and it's work awesome, but when I try **Infura** as ethereum node, I have problem with URI constructor for Web3.HTTPProvider. So this PR add possibility to set any formatted URI.