### PR TITLE
Fix bug with exception on failed transaction in block

### DIFF
--- a/django_ethereum_events/event_listener.py
+++ b/django_ethereum_events/event_listener.py
@@ -61,6 +61,10 @@ class EventListener:
         if block and block.get('hash'):
             for tx in block['transactions']:
                 receipt = self.web3.eth.getTransactionReceipt(tx)
+
+                if receipt is None:
+                    continue
+
                 for log in receipt.get('logs', []):
                     address = log['address']
                     if address in self.decoder.watched_addresses and \


### PR DESCRIPTION
I found this bug on Ropsten network.
In loop when we found bad transaction in block (failed due contract execution for example) we get exception and block processing will stacked on failed block.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django_ethereum_events/tasks.py", line 51, in event_listener
    listener.execute()
  File "/usr/local/lib/python3.7/site-packages/django_ethereum_events/event_listener.py", line 137, in execute
    logs = self.get_block_logs(block)
  File "/usr/local/lib/python3.7/site-packages/django_ethereum_events/event_listener.py", line 64, in get_block_logs
    for log in receipt.get('logs', []):
AttributeError: 'NoneType' object has no attribute 'get'
```

Also this one block will be never processed: https://ropsten.etherscan.io/txs?block=6422276

I think we can easily fix this if will ignore failed transactions.
